### PR TITLE
Push Docker images to GCR instead of Codefresh

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login eu.gcr.io --username fropenbanking --password ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        run :echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login r.cfcr.io --username fropenbanking --password ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
+        run: docker login eu.gcr.io --username fropenbanking --password ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run :echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        run: echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login  -u _json_key --password-stdin https://eu.gcr.io < ${{ parseJSON(secrets.GCR_JSON_KEY) }}
+        run: echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login  -u _json_key --password-stdin https://eu.gcr.io < ${{ secrets.GCR_JSON_KEY }}
+        run: docker login  -u _json_key --password-stdin https://eu.gcr.io < echo ${{ secrets.GCR_JSON_KEY }}
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: docker login  -u _json_key --password-stdin https://eu.gcr.io < echo ${{ secrets.GCR_JSON_KEY }}
+        run: docker login  -u _json_key --password-stdin https://eu.gcr.io < ${{ parseJSON(secrets.GCR_JSON_KEY) }}
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven2-${{ hashFiles('**/pom.xml') }}
       - name: Docker login
-        run: echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+        run: docker login  -u _json_key --password-stdin https://eu.gcr.io < ${{ secrets.GCR_JSON_KEY }}
 
       - name: Check Copyright
         run: mvn license:check

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,10 +54,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/auth:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/auth:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/auth/docker/Dockerfile -t eu.gcr.io/openbanking/obri/auth:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/auth:$BUILD_VERSION
+          docker build -f projects/auth/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION
   build_swagger:
     name: Build Swagger App
     runs-on: ubuntu-latest
@@ -81,10 +81,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image eu.gcr.io/openbanking/obri/swagger-ui:${BUILD_VERSION}"
+          echo "Building docker image eu.gcr.io/openbanking-214714/obri/swagger-ui:${BUILD_VERSION}"
           docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
-          docker build -f projects/swagger/docker/Dockerfile -t eu.gcr.io/openbanking/obri/swagger-ui:$BUILD_VERSION .
-          docker push eu.gcr.io/openbanking/obri/swagger-ui:$BUILD_VERSION
+          docker build -f projects/swagger/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -54,10 +54,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/auth:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/auth/docker/Dockerfile -t r.cfcr.io/openbanking/obri/auth:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/auth:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/auth:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/auth/docker/Dockerfile -t eu.gcr.io/openbanking/obri/auth:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/auth:$BUILD_VERSION
   build_swagger:
     name: Build Swagger App
     runs-on: ubuntu-latest
@@ -81,10 +81,10 @@ jobs:
         working-directory: ./forgerock-openbanking-ui
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
-          echo "Building docker image r.cfcr.io/openbanking/obri/swagger-ui:${BUILD_VERSION}"
-          docker login r.cfcr.io -u fropenbanking -p ${{ secrets.CODEFRESH_DOCKER_REGISTRY_API_KEY }}
-          docker build -f projects/swagger/docker/Dockerfile -t r.cfcr.io/openbanking/obri/swagger-ui:$BUILD_VERSION .
-          docker push r.cfcr.io/openbanking/obri/swagger-ui:$BUILD_VERSION
+          echo "Building docker image eu.gcr.io/openbanking/obri/swagger-ui:${BUILD_VERSION}"
+          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          docker build -f projects/swagger/docker/Dockerfile -t eu.gcr.io/openbanking/obri/swagger-ui:$BUILD_VERSION .
+          docker push eu.gcr.io/openbanking/obri/swagger-ui:$BUILD_VERSION
   update_ob_deploy:
     name: Update ob-deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/auth:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/auth/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION
   build_swagger:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/swagger-ui:${BUILD_VERSION}"
-          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY_BASE64 }}" | base64 -d | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/swagger/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/auth:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/auth/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION
   build_swagger:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/swagger-ui:${BUILD_VERSION}"
-          docker login eu.gcr.io -u _json_key -p ${{ secrets.GCR_JSON_KEY }}
+          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/swagger/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION
   update_ob_deploy:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/auth:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/auth/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/auth:$BUILD_VERSION
   build_swagger:
@@ -82,7 +82,7 @@ jobs:
         run: |
           export BUILD_VERSION=$(jq -r ".project_version" package.json)-${GITHUB_SHA::7}
           echo "Building docker image eu.gcr.io/openbanking-214714/obri/swagger-ui:${BUILD_VERSION}"
-          echo ${{ secrets.GCR_JSON_KEY }} | docker login eu.gcr.io -u _json_key --password-stdin
+          echo "${{ secrets.GCR_JSON_KEY }}" | docker login eu.gcr.io -u _json_key --password-stdin
           docker build -f projects/swagger/docker/Dockerfile -t eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION .
           docker push eu.gcr.io/openbanking-214714/obri/swagger-ui:$BUILD_VERSION
   update_ob_deploy:


### PR DESCRIPTION
Push/pull Docker images to/from GCR instead of Codefresh. This references a new Github secret called `GCR_JSON_KEY` which is a new access token for Google Cloud with a limited scope for the container registry.

Part of https://github.com/ForgeCloud/ob-deploy/issues/468