### PR TITLE
Release/1.0.77

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           server-password: MAVEN_CENTRAL_TOKEN # env variable for token in deploy
 
       - name: Release package
-        run:  mvn -B deploy
+        run:  mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip
         env:
           MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -111,12 +111,12 @@ jobs:
       - name: Commit ob-deploy version update
         working-directory: ./ob-deploy
         run: |
-          jq -M  '[ .[] | if ((.service == "auth" or .service == "swagger-ui") and (.helmReference  | contains("obri-helm-charts/ui-template"))) then .version |= "${{ steps.version.outputs.BUILD_VERSION }}" else . end ]' client_releases/master-dev/releases.json > client_releases/master-dev/releases.json.tmp
+          jq -M  '[ .[] | if ((.service == "auth-ui" or .service == "swagger-ui") and (.helmReference  | contains("obri-helm-charts/ui-template"))) then .version |= "${{ steps.version.outputs.BUILD_VERSION }}" else . end ]' client_releases/master-dev/releases.json > client_releases/master-dev/releases.json.tmp
           mv client_releases/master-dev/releases.json.tmp client_releases/master-dev/releases.json
           git config --global user.email "codefresh@codefresh.io"
           git config --global user.name "Codefresh"
           git add client_releases/master-dev/releases.json
-          git commit --allow-empty -m "Bumping Auth & Swagger UI version ${{ steps.version.outputs.BUILD_VERSION }}"
+          git commit --allow-empty -m "Bumping Auth UI & Swagger UI version ${{ steps.version.outputs.BUILD_VERSION }}"
       - name: Temporarily disable "include administrators" protection
         uses: benjefferies/branch-protection-bot@master
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 .vscode
 *.releaseBackup
 release.properties
+*.next
+*.tag

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+target/
+.project
+.classpath
+.settings
+.factorypath
+.vscode
+*.releaseBackup
+release.properties

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.78-SNAPSHOT</version>
+        <version>1.0.77-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77-SNAPSHOT</version>
+        <version>1.0.77</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77</version>
+        <version>1.0.78-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.78-SNAPSHOT</version>
+        <version>1.0.77-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77-SNAPSHOT</version>
+        <version>1.0.77</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77</version>
+        <version>1.0.78-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.78-SNAPSHOT</version>
+        <version>1.0.77-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77-SNAPSHOT</version>
+        <version>1.0.77</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77</version>
+        <version>1.0.78-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.78-SNAPSHOT</version>
+        <version>1.0.77-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77-SNAPSHOT</version>
+        <version>1.0.77</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77</version>
+        <version>1.0.78-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.78-SNAPSHOT</version>
+        <version>1.0.77-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77-SNAPSHOT</version>
+        <version>1.0.77</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77</version>
+        <version>1.0.78-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -40,6 +40,15 @@
 
   <build>
     <plugins>
+      <!-- to skip the deploy/release for this module -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>dockerfile-maven-plugin</artifactId>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.77</version>
+    <version>1.0.78-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -20,8 +20,7 @@
     under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.forgerock.openbanking</groupId>
   <artifactId>forgerock-openbanking-ui</artifactId>
@@ -35,7 +34,7 @@
   <parent>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.77-SNAPSHOT</version>
+    <version>1.0.77</version>
   </parent>
 
   <build>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -20,7 +20,8 @@
     under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.forgerock.openbanking</groupId>
   <artifactId>forgerock-openbanking-ui</artifactId>
@@ -34,20 +35,11 @@
   <parent>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.78-SNAPSHOT</version>
+    <version>1.0.77-SNAPSHOT</version>
   </parent>
 
   <build>
     <plugins>
-      <!-- to skip the deploy/release for this module -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>dockerfile-maven-plugin</artifactId>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -39,6 +39,15 @@
 
   <build>
     <plugins>
+      <!-- to skip the deploy/release for this module -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.spotify</groupId>
         <artifactId>dockerfile-maven-plugin</artifactId>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.78-SNAPSHOT</version>
+        <version>1.0.77-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77-SNAPSHOT</version>
+        <version>1.0.77</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.77</version>
+        <version>1.0.78-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.77</version>
+    <version>1.0.78-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -141,7 +141,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>1.0.77</tag>
+        <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.77-SNAPSHOT</version>
+    <version>1.0.77</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -141,7 +141,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>HEAD</tag>
+        <tag>1.0.77</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.78-SNAPSHOT</version>
+    <version>1.0.77-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>


### PR DESCRIPTION
Release 1.0.77
- Prepare for the next release
- Improvements to run auth UI and swagger UI in local with fast build using maven and dev-ob subdomain
- Skip build the ui on deploy/release
- UI images tag extension
- Change the auth app to auth-ui app
- Changed the github action descriptor (ui.yml) step update-ob-deploy to use the new name service for auth-ui 