### PR TITLE
Allign OpenBanking and Forgerock software statement fields - and release 1.0.83

### DIFF
--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.84-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83-SNAPSHOT</version>
+        <version>1.0.83</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.84-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83-SNAPSHOT</version>
+        <version>1.0.83</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.84-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83-SNAPSHOT</version>
+        <version>1.0.83</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/SoftwareStatement.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/SoftwareStatement.java
@@ -20,6 +20,7 @@
  */
 package com.forgerock.openbanking.model;
 
+import lombok.Data;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -50,7 +51,21 @@ public class SoftwareStatement {
     @LastModifiedDate
     public Date updated;
     private String applicationId;
-    private String organisationId;
+
+
+    /**
+     * The software ID is the same as the ForgeRock Application Id. It is included here to make logic simpler for
+     * TPPS wishing to support message signing with both ForgeRock certificates and OB issued certificates. OB issued
+     * Software Statements contain software_id and org_id fields and specify that these values should be used in the
+     * iss field of a jws header (message signing header). Having both the software_id and org_id fields in the
+     * ForgeRock software statement will make TPP and our own test logic easier when performing message signing.
+     */
+    private String software_id;
+    /**
+     * The organisation ID - this is the organisation in the ForgeRock directory under which this
+     * application/software id has been created.
+     */
+    private String org_id;
 
     public enum Mode {
         TEST, LIVE
@@ -201,7 +216,19 @@ public class SoftwareStatement {
         this.applicationId = applicationId;
     }
 
-    public String getOrganisationId() { return organisationId;}
+    public String getSoftware_id() {
+        return software_id;
+    }
 
-    public void setOrganisationId(String organisationId) {this.organisationId = organisationId;}
+    public void setSoftware_id(String software_id) {
+        this.software_id = software_id;
+    }
+
+    public String getOrg_id() {
+        return org_id;
+    }
+
+    public void setOrg_id(String org_id) {
+        this.org_id = org_id;
+    }
 }

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.84-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83-SNAPSHOT</version>
+        <version>1.0.83</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.84-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83-SNAPSHOT</version>
+        <version>1.0.83</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.83-SNAPSHOT</version>
+    <version>1.0.83</version>
   </parent>
 
   <build>

--- a/forgerock-openbanking-ui/pom.xml
+++ b/forgerock-openbanking-ui/pom.xml
@@ -34,7 +34,7 @@
   <parent>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.83</version>
+    <version>1.0.84-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83</version>
+        <version>1.0.84-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.0.83-SNAPSHOT</version>
+        <version>1.0.83</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.83-SNAPSHOT</version>
+    <version>1.0.83</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -141,7 +141,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>HEAD</tag>
+        <tag>1.0.83</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <groupId>com.forgerock.openbanking</groupId>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.0.83</version>
+    <version>1.0.84-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -141,7 +141,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>1.0.83</tag>
+        <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
It would help TPPs doing message signing if org_id and software_id
fields existing in both ForgeRock and OpenBanking issued Software
Statements. This will facilitate the creation of JWS signatures for
message signing.

Part fix for https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/12