### PR TITLE
422: Refactoring Tpp - applying law of dimeter

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
@@ -27,6 +27,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.codec.binary.StringUtils;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -36,6 +37,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.text.ParseException;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 
@@ -80,5 +82,15 @@ public class Tpp {
             }
         }
         return null;
+    }
+
+    public Optional<String> getRegistrationAccessToken(){
+        if(registrationResponse != null){
+            String registationAccessToken = registrationResponse.getRegistrationAccessToken();
+            if(registationAccessToken != null && !registationAccessToken.isBlank()) {
+                return Optional.of(registationAccessToken);
+            }
+        }
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
Tpp used to return it's OIDCRegistrationResponse and allow clients to
then query that object for information. This breaks the law of dimiter.
Instead the Tpp can return data held within it's agregated classes to
reduce coupling. In this case Tpp can now be asked for the Tpp's
registration access token. This means the caller of the Tpp class
doesn't need to know anything about the OIDCRegistration response.

This helps write tests that were required during work to improve
logging and error handling for the DELETE /register/{{ClientId}}
endpoints.

Issue: https://github.com/OpenBankingToolkit/openbanking-aspsp/issues/422