### PR TITLE
38: Duplication version error fix

### DIFF
--- a/forgerock-openbanking-upgrade/src/main/java/com/forgerock/openbanking/upgrade/EntitiesVersionRepository.java
+++ b/forgerock-openbanking-upgrade/src/main/java/com/forgerock/openbanking/upgrade/EntitiesVersionRepository.java
@@ -22,7 +22,13 @@ package com.forgerock.openbanking.upgrade;
 
 import com.forgerock.openbanking.upgrade.model.version.EntitiesVersion;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 
 public interface EntitiesVersionRepository extends MongoRepository<EntitiesVersion, String> {
+
+    Optional<EntitiesVersion> findByVersionAndStatus(@Param("version") String version, @Param("status") String status);
+
 }

--- a/forgerock-openbanking-upgrade/src/main/java/com/forgerock/openbanking/upgrade/UpgradeApplication.java
+++ b/forgerock-openbanking-upgrade/src/main/java/com/forgerock/openbanking/upgrade/UpgradeApplication.java
@@ -105,7 +105,9 @@ public abstract class UpgradeApplication implements CommandLineRunner {
             List<EntitiesVersion> uniques = allVersions.stream()
                     .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparing(EntitiesVersion::getVersion))),
                             ArrayList::new));
-            allVersions.stream().filter(version -> !uniques.contains(version)).collect(Collectors.toList())
+            allVersions.stream().filter(version -> !uniques.contains(version))
+                    .filter(entitiesVersion -> entitiesVersion.getStatus().equals(EntitiesVersion.UpgradeStatus.UPGRADED))
+                    .collect(Collectors.toList())
                     .forEach(entitiesVersion -> deleteEntitiesVersion(entitiesVersion));
             return uniques;
         }


### PR DESCRIPTION
- Added clean duplication versions method when collect the entitiesVersion to get unique versions
- Added new repository method to get the current upgrade system version if exist
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/38