### PR TITLE
775: Allow Tpps to register more than one Software Statement 

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/AuthorisationClaim.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/AuthorisationClaim.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class AuthorisationClaim {
+    String member_state;
+    List<String> roles;
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatement.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatement.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.model;
+
+import java.util.List;
+
+public interface DirectorySoftwareStatement {
+
+    String getJti();
+    
+    String getSoftware_jwks_endpoint();
+
+    List<String> getSoftware_redirect_uris();
+
+    String getIss();
+
+    String getSoftware_client_id();
+
+    String getSoftware_id();
+
+    String getOrg_name();
+
+    String getOrg_id();
+
+    String getSoftware_logo_uri();
+
+    String getSoftware_tos_uri();
+
+    String getSoftware_policy_uri();
+
+    List<String> getSoftware_roles();
+
+    boolean hasRole(SoftwareStatementRole role);
+
+    List<OrganisationContact> getOrg_contacts();
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatementOpenBanking.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatementOpenBanking.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.Date;
+import java.util.List;
+
+@Builder
+@Data
+@EqualsAndHashCode(callSuper=false)
+public class DirectorySoftwareStatementOpenBanking implements DirectorySoftwareStatement {
+    String iss;
+    Date iat;
+    String jti;
+    String software_environment;
+    String software_mode;
+    String software_id;
+    String software_client_id;
+    String software_client_name;
+    String software_client_description;
+    Double software_version;
+    String software_client_uri;
+    List<String> software_redirect_uris;
+    List<String> software_roles;
+    OrganisationAuthorityClaims organisation_competent_authority_claims;
+    String software_logo_uri;
+    String org_status;
+    String org_id;
+    String org_name;
+    List<OrganisationContact> org_contacts;
+    String org_jwks_endpoint;
+    String org_jwks_revoked_endpoint;
+    String software_jwks_endpoint;
+    String software_jwks_revoked_endpoint;
+    String software_policy_uri;
+    String software_tos_uri;
+    String software_on_behalf_of_org;
+
+    @Override
+    public boolean hasRole(SoftwareStatementRole role) {
+        return software_roles.contains(role.name());
+    }
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/OrganisationAuthorityClaims.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/OrganisationAuthorityClaims.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class OrganisationAuthorityClaims {
+
+    String authority_id;
+    String registration_id;
+    String status;
+    List<AuthorisationClaim> authorizations;
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/OrganisationContact.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/OrganisationContact.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OrganisationContact {
+    String name;
+    String email;
+    String phone;
+    String type;
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
@@ -56,10 +56,11 @@ public class Tpp {
     @Indexed
     private String softwareId;
     @Indexed
-    private String organisationId;
+    private String authorisationNumber;
     @Indexed
     private String clientId;
-    private DirectorySoftwareStatement ssa;
+    private String ssa;
+    private DirectorySoftwareStatement directorySoftwareStatement;
     private String tppRequest;
     private OIDCRegistrationResponse registrationResponse;
 
@@ -71,12 +72,12 @@ public class Tpp {
     private Set<SoftwareStatementRole> types = new HashSet<>();
 
     public DirectorySoftwareStatement getSsaClaim() {
-        return ssa;
+        return directorySoftwareStatement;
     }
 
     public String getLogo() {
-        if (getSsa() != null) {
-            return ssa.getSoftware_logo_uri();
+        if (getDirectorySoftwareStatement() != null) {
+            return directorySoftwareStatement.getSoftware_logo_uri();
         }
         return null;
     }

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
@@ -27,7 +27,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.codec.binary.StringUtils;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -55,6 +54,10 @@ public class Tpp {
     public String officialName;
     @Indexed
     private String certificateCn;
+    @Indexed
+    private String softwareId;
+    @Indexed
+    private String organisationId;
     @Indexed
     private String clientId;
     private String ssa;

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/Tpp.java
@@ -20,24 +20,23 @@
  */
 package com.forgerock.openbanking.model;
 
-import com.forgerock.openbanking.constants.OpenBankingConstants;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
 import com.forgerock.openbanking.model.oidc.OIDCRegistrationResponse;
-import com.nimbusds.jwt.JWTClaimsSet;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.text.ParseException;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 
 @Data
@@ -60,7 +59,7 @@ public class Tpp {
     private String organisationId;
     @Indexed
     private String clientId;
-    private String ssa;
+    private DirectorySoftwareStatement ssa;
     private String tppRequest;
     private OIDCRegistrationResponse registrationResponse;
 
@@ -71,18 +70,13 @@ public class Tpp {
 
     private Set<SoftwareStatementRole> types = new HashSet<>();
 
-    public JWTClaimsSet getSsaClaim() throws ParseException {
-        return JWTClaimsSet.parse(ssa);
+    public DirectorySoftwareStatement getSsaClaim() {
+        return ssa;
     }
 
     public String getLogo() {
         if (getSsa() != null) {
-            try {
-                JWTClaimsSet claims = getSsaClaim();
-                return claims.getStringClaim(OpenBankingConstants.SSAClaims.SOFTWARE_LOGO_URI);
-            } catch (ParseException e) {
-                //Couldn't read claims
-            }
+            return ssa.getSoftware_logo_uri();
         }
         return null;
     }

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/repositories/TppRepository.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/repositories/TppRepository.java
@@ -33,6 +33,8 @@ public interface TppRepository extends MongoRepository<Tpp, String> {
 
     Collection<Tpp> findByCertificateCn(@Param("certificateCn") String certificateCn);
 
+    Collection<Tpp> findByOrganisationId(@Param("organisationId") String organisationId);
+
     Tpp findByClientId(@Param("clientId") String clientId);
 
     Collection<Tpp> findByCreatedBetween(

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/repositories/TppRepository.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/repositories/TppRepository.java
@@ -33,7 +33,7 @@ public interface TppRepository extends MongoRepository<Tpp, String> {
 
     Collection<Tpp> findByCertificateCn(@Param("certificateCn") String certificateCn);
 
-    Collection<Tpp> findByOrganisationId(@Param("organisationId") String organisationId);
+    Collection<Tpp> findByAuthorisationNumber(@Param("authorisationNumber") String authorisationNumber);
 
     Tpp findByClientId(@Param("clientId") String clientId);
 


### PR DESCRIPTION
Refactor the Tpp Class to hold sufficient information to allow searching for Tpp record based on authorizationNumber, add orgId and softwareId.

Store the full DirectorySoftwareStatement in the Tpp record rathern than just the serialized json software statement.

-----

Add new repository method `findByAuthorisationNumber` and the Tpp class has both the softwareId and AuthorisationNumber that stores the certificate subject 2.5.4.97.

The Tpp class will now store the SSA as both string and object making it backwards compatible with old registrations. New registrations will use the DirectorySoftwareStatement.

issue: https://github.com/ForgeCloud/ob-deploy/issues/775