### PR TITLE
Release 1.2.5

### DIFF
--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-annotations/pom.xml
+++ b/forgerock-openbanking-annotations/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-annotations/pom.xml
+++ b/forgerock-openbanking-annotations/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5-SNAPSHOT</version>
+        <version>1.2.5</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -139,7 +139,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>1.2.5</tag>
+        <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.2.5-SNAPSHOT</version>
+    <version>1.2.5</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -139,7 +139,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.5</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Includes #132 

Refactor the Tpp Class to hold sufficient information to allow searching for Tpp record based on authorizationNumber, add orgId and softwareId.

Store the full DirectorySoftwareStatement in the Tpp record rathern than just the serialized json software statement.

Add new repository method findByAuthorisationNumber and the Tpp class has both the softwareId and AuthorisationNumber that stores the certificate subject 2.5.4.97.

The Tpp class will now store the SSA as both string and object making it backwards compatible with old registrations. New registrations will use the DirectorySoftwareStatement.

issue: ForgeCloud/ob-deploy#775