### PR TITLE
793: Can serialise OpenBanking software statements

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatement.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatement.java
@@ -31,7 +31,7 @@ import java.util.List;
         property = "iss")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = DirectorySoftwareStatementOpenBanking.class, name = "ForgeRock"),
-        @JsonSubTypes.Type(value = DirectorySoftwareStatementOpenBanking.class, name = "OpenBanking")})
+        @JsonSubTypes.Type(value = DirectorySoftwareStatementOpenBanking.class, name = "OpenBanking Ltd")})
 public interface DirectorySoftwareStatement {
 
     String getJti();

--- a/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/model/DirectorySoftwareStatementTest.java
+++ b/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/model/DirectorySoftwareStatementTest.java
@@ -61,4 +61,25 @@ public class DirectorySoftwareStatementTest extends TestCase {
         DirectorySoftwareStatement value = mapper.readValue(instream, DirectorySoftwareStatement.class);
         assertNotNull(value);
     }
+
+    @Test
+    public void testSerialisationOBIssuer() throws IOException {
+        // Given
+        DirectorySoftwareStatement directorySoftwareStatement =
+                DirectorySoftwareStatementOpenBanking.builder()
+                        .software_id("software_id")
+                        .software_client_description("software client description")
+                        .iss("OpenBanking Ltd")
+                        .software_client_id("software_client_id").build();
+
+
+        Writer outstream = new StringWriter();
+        mapper.writeValue(outstream, directorySoftwareStatement);
+
+        String serialised = outstream.toString();
+
+        Reader instream = new StringReader(serialised);
+        DirectorySoftwareStatement value = mapper.readValue(instream, DirectorySoftwareStatement.class);
+        assertNotNull(value);
+    }
 }


### PR DESCRIPTION
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793