### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatement.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatement.java
@@ -20,14 +20,17 @@
  */
 package com.forgerock.openbanking.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.List;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        visible = true,
         property = "iss")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = DirectorySoftwareStatementOpenBanking.class, name = "ForgeRock"),
@@ -35,7 +38,7 @@ import java.util.List;
 public interface DirectorySoftwareStatement {
 
     String getJti();
-    
+
     String getSoftware_jwks_endpoint();
 
     List<String> getSoftware_redirect_uris();

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatementOpenBanking.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/DirectorySoftwareStatementOpenBanking.java
@@ -30,7 +30,7 @@ import java.util.List;
 @Data
 @EqualsAndHashCode(callSuper=false)
 @NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class DirectorySoftwareStatementOpenBanking implements DirectorySoftwareStatement {
     String iss;
     Date iat;

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/SoftwareStatement.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/SoftwareStatement.java
@@ -55,6 +55,7 @@ public class SoftwareStatement {
     @LastModifiedDate
     public Date updated;
     private String applicationId;
+    private String iss;
 
     /**
      * The software ID is the same as the ForgeRock Application Id. It is included here to make logic simpler for
@@ -86,6 +87,7 @@ public class SoftwareStatement {
 
         redirectUris = new ArrayList<>();
         mode = Mode.TEST;
+        this.iss = "ForgeRock";
     }
 
     public enum Mode {

--- a/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/model/DirectorySoftwareStatementTest.java
+++ b/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/model/DirectorySoftwareStatementTest.java
@@ -45,12 +45,11 @@ public class DirectorySoftwareStatementTest extends TestCase {
     public void testSerialisation() throws IOException {
         // Given
         InputStream ssa = getSsa("SSAs/ForgeRockDirectorySSA.json");
-
-        Reader instream = new InputStreamReader(ssa);
-        DirectorySoftwareStatement value = mapper.readValue(instream, DirectorySoftwareStatement.class);
+        DirectorySoftwareStatement value = mapper.readValue(ssa, DirectorySoftwareStatement.class);
+        assertNotNull(value.getIss());
+        assertNotNull(value);
         OutputStream os = new ByteArrayOutputStream();
         mapper.writeValue(os, value);
-        assertNotNull(value);
     }
 
     @Test
@@ -60,7 +59,7 @@ public class DirectorySoftwareStatementTest extends TestCase {
 
         Reader instream = new InputStreamReader(ssa);
         DirectorySoftwareStatement value = mapper.readValue(instream, DirectorySoftwareStatement.class);
-
+        assertNotNull(value.getIss());
         OutputStream os = new ByteArrayOutputStream();
         mapper.writeValue(os, value);
 


### PR DESCRIPTION
I found that when data was deserialised from mongo the iss field was
invisible. This was recreated in the DirectorySoftwareStatementTest and
fixed by the addition of a visible = true flag in the @JsonTypeInfo
annotation arguments.

Also in this PR is the addition of the iss field to the
SoftwareStatement that represents the software statements created by the
ForgeRock directory. This is necessary as the Postman tests use the
directory server API to obtain a current software statement and that
didn't have an iss field set, although the obtained by the directory UI
did have an iss statement. The lack of the iss field meant that the
SoftwareStatement couldn't be serialised/deserialised and caused
problems for the Postman tests.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793