### PR TITLE
Create release 1.2.9

### DIFF
--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-annotations/pom.xml
+++ b/forgerock-openbanking-annotations/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-annotations/pom.xml
+++ b/forgerock-openbanking-annotations/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9-SNAPSHOT</version>
+        <version>1.2.9</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.9</version>
+        <version>1.2.10-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.2.9-SNAPSHOT</version>
+    <version>1.2.9</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -139,7 +139,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.9</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.2.9</version>
+    <version>1.2.10-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -139,7 +139,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>1.2.9</tag>
+        <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
793: Fix more issues with DirectorySoftwareStatement serialisation

I found that when data was deserialised from mongo the iss field was
invisible. This was recreated in the DirectorySoftwareStatementTest and
fixed by the addition of a visible = true flag in the @JsonTypeInfo
annotation arguments.

Also in this PR is the addition of the iss field to the
SoftwareStatement that represents the software statements created by the
ForgeRock directory. This is necessary as the Postman tests use the
directory server API to obtain a current software statement and that
didn't have an iss field set, although the obtained by the directory UI
did have an iss statement. The lack of the iss field meant that the
SoftwareStatement couldn't be serialised/deserialised and caused
problems for the Postman tests.

PR: #140