### PR TITLE
45: Release 1.2.14 & use latest uk datamodel

### DIFF
--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-am/pom.xml
+++ b/forgerock-openbanking-am/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-annotations/pom.xml
+++ b/forgerock-openbanking-annotations/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-annotations/pom.xml
+++ b/forgerock-openbanking-annotations/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwt/pom.xml
+++ b/forgerock-openbanking-jwt/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-model/pom.xml
+++ b/forgerock-openbanking-model/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-oidc/pom.xml
+++ b/forgerock-openbanking-oidc/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-ssl/pom.xml
+++ b/forgerock-openbanking-ssl/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.15-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-upgrade/pom.xml
+++ b/forgerock-openbanking-upgrade/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-commons</artifactId>
-        <version>1.2.14-SNAPSHOT</version>
+        <version>1.2.14</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.2.14-SNAPSHOT</version>
+    <version>1.2.14</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -139,7 +139,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>HEAD</tag>
+        <tag>1.2.14</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>ForgeRock OpenBanking Reference Implementation - commons</name>
     <artifactId>forgerock-openbanking-starter-commons</artifactId>
-    <version>1.2.14</version>
+    <version>1.2.15-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -139,7 +139,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-common.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-common.git</url>
-        <tag>1.2.14</tag>
+        <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
45: Use fixed uk-datamodel for 3.1.8

OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45