### PR TITLE
815: Add enums to allow CustomerInfo endpoint in discovery

### DIFF
--- a/forgerock-openbanking-annotations/src/main/java/com/forgerock/openbanking/api/annotations/OBGroupName.java
+++ b/forgerock-openbanking-annotations/src/main/java/com/forgerock/openbanking/api/annotations/OBGroupName.java
@@ -25,6 +25,7 @@ public enum OBGroupName {
     PISP("pisp"),
     CBPII("cbpii"),
     EVENT(""),
+    INFO("info"),
     NONE("");
 
     private String reference;

--- a/forgerock-openbanking-annotations/src/main/java/com/forgerock/openbanking/api/annotations/OBReference.java
+++ b/forgerock-openbanking-annotations/src/main/java/com/forgerock/openbanking/api/annotations/OBReference.java
@@ -174,6 +174,10 @@ public enum OBReference {
     GET_DOMESTIC_VRP_PAYMENT("GetDomesticVrpPayment"),
     GET_DOMESTIC_VRP_PAYMENT_DETAILS("GetDomesticVrpPaymentDetails"),
 
+    // Customer info endpoints
+    CUSTOMER_INFO("CustomerInfo"),
+    GET_CUSTOMER_INFO("GetCustomerInfo"),
+
     NONE("");
 
     private String reference;

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.8</version>
+        <version>1.2.9-SNAPSHOT</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Note: We now pull in a snapshot of openbanking-parent while we develop
this feature. We will need to change this to release version when
stable.

Issue: https://github.com/OpenBankingToolkit/openbanking-parent/pull/284