### PR TITLE
871: Adding custom Jackson serializer & deserializer for LocalDate objects

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/serialiser/IsoLocalDateDeserializer.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/serialiser/IsoLocalDateDeserializer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.serialiser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.joda.time.LocalDate;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
+
+public class IsoLocalDateDeserializer extends StdDeserializer<LocalDate> {
+    public IsoLocalDateDeserializer() {
+        super(LocalDate.class);
+    }
+
+    @Override
+    public LocalDate deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        return ISODateTimeFormat.dateParser().parseLocalDate(jsonParser.getText());
+    }
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/serialiser/IsoLocalDateSerializer.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/serialiser/IsoLocalDateSerializer.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.serialiser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.joda.time.LocalDate;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.io.IOException;
+
+public class IsoLocalDateSerializer extends StdSerializer<LocalDate>  {
+    public IsoLocalDateSerializer() {
+        super(LocalDate.class);
+    }
+
+    @Override
+    public void serialize(LocalDate localDate, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        jsonGenerator.writeObject(ISODateTimeFormat.date().print(localDate));
+    }
+}

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/serialiser/config/SerialiserConfig.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/serialiser/config/SerialiserConfig.java
@@ -28,6 +28,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jwt.JWTClaimsSet;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.springframework.boot.actuate.trace.http.HttpTrace;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +44,8 @@ public class SerialiserConfig {
             jacksonObjectMapperBuilder.serializerByType(Base64.class, new Base64Serialiser());
             jacksonObjectMapperBuilder.serializerByType(DateTime.class, new IsoDateTimeSerializer());
             jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new IsoDateTimeDeserializer());
+            jacksonObjectMapperBuilder.serializerByType(LocalDate.class, new IsoLocalDateSerializer());
+            jacksonObjectMapperBuilder.deserializerByType(LocalDate.class, new IsoLocalDateDeserializer());
             jacksonObjectMapperBuilder.deserializerByType(OBExternalPermissions1Code.class, new OBExternalPermissions1CodeDeserializer());
             jacksonObjectMapperBuilder.deserializerByType(JWTClaimsSet.class, new JWTClaimsSetDeserializer());
             jacksonObjectMapperBuilder.serializerByType(OBExternalPermissions1Code.class, new OBExternalPermissions1CodeSerializer());

--- a/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/serialiser/IsoLocalDateDeserializerTest.java
+++ b/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/serialiser/IsoLocalDateDeserializerTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.serialiser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IsoLocalDateDeserializerTest {
+    @Mock
+    private JsonParser jsonParser;
+    @Mock
+    private DeserializationContext deserializationContext;
+
+    @Test
+    public void testDeserialize() throws IOException {
+        BDDMockito.given(jsonParser.getText()).willReturn("2022-06-10");
+        final IsoLocalDateDeserializer deserializer = new IsoLocalDateDeserializer();
+
+        LocalDate date = deserializer.deserialize(jsonParser, deserializationContext);
+        assertEquals(new LocalDate(2022, 6, 10), date);
+    }
+}

--- a/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/serialiser/IsoLocalDateSerializerTest.java
+++ b/forgerock-openbanking-model/src/test/java/com/forgerock/openbanking/serialiser/IsoLocalDateSerializerTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.openbanking.serialiser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IsoLocalDateSerializerTest {
+    @Mock
+    private JsonGenerator jsonGenerator;
+    @Mock
+    private SerializerProvider serializerProvider;
+
+    @Test
+    public void testSerialize() throws IOException {
+        final IsoLocalDateSerializer serializer = new IsoLocalDateSerializer();
+        final LocalDate date = new LocalDate(2022, 6, 10);
+
+        serializer.serialize(date, jsonGenerator, serializerProvider);
+
+        Mockito.verify(jsonGenerator).writeObject("2022-06-10");
+    }
+}


### PR DESCRIPTION
Fixing an issue where LocalDate objects are being JSON serialized by the default serializer which produces output as an int[].

Adding new Jackson serializer classes: IsoLocalDateSerializer & IsoLocalDateDeserializer to produce an ISO date string of the format "yyyy-MM-dd" for LocalDate objects. These classes are then configured to be used when serializing any LocalDate object using Jackson.

Issue: https://github.com/ForgeCloud/ob-deploy/issues/871