### PR TITLE
883: Adding Error messages for VRP extended validation rules

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/error/ErrorCode.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/error/ErrorCode.java
@@ -92,6 +92,13 @@ public enum ErrorCode implements StandardErrorCode {
     OBRI_REQUEST_VRP_RISK_DOES_NOT_MATCH_CONSENT("OBRI.Request.Data.risk.not.matching.consent.risk"),
     OBRI_REQUEST_VRP_LIMIT_BREACH_SIMULATION_INVALID_HEADER_VALUE("OBRI.Request.Data.vrp.limit.breach.simulation.invalid.header.value"),
     OBRI_REQUEST_VRP_LIMIT_BREACH_SIMULATION_NO_MATCHING_LIMIT_IN_CONSENT("OBRI.Request.Data.vrp.limit.breach.simulation.no.matching.limit.in.consent"),
+    OBRI_REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL("OBRI.Request.vrp.MaxIndividual.Amount.Too.Small"),
+    OBRI_REQUEST_VRP_TYPE_MUST_BE_SWEEPING("OBRI.Request.vrp.VrpType.must.be.sweeping"),
+    OBRI_REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID("OBRI.Request.vrp.risk.PaymentContextCode.invalid"),
+    OBRI_REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID("OBRI.Request.vrp.PSUAuthenticationMethods.invalid"),
+    OBRI_REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID("OBRI.Request.vrp.consent.ValidToDateTime.invalid"),
+    OBRI_REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID("OBRI.Request.vrp.consent.ValidFromDateTime.invalid"),
+    OBRI_REQUEST_AMOUNT_MAX_2_DP("OBRI.Request.Amount.Max.2.DecimalPlaces"),
 
     OBRI_SERVER_INTERNAL_ERROR("OBRI.Server.InternalError"),
     OBRI_REQUEST_UNDEFINED_ERROR_YET("OBRI.Request.ErrorUnknown"),

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/error/OBRIErrorType.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/error/OBRIErrorType.java
@@ -563,13 +563,41 @@ public enum OBRIErrorType {
             HttpStatus.BAD_REQUEST,
             ErrorCode.OBRI_REQUEST_VRP_LIMIT_BREACH_SIMULATION_NO_MATCHING_LIMIT_IN_CONSENT,
             "No Periodic Limit found in the consent for Header value '%s', unable to simulate the payment limitation breach"),
-    REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL, "'MaximumIndividualAmount' must be >= %.2f"),
-    REQUEST_VRP_TYPE_MUST_BE_SWEEPING(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_TYPE_MUST_BE_SWEEPING, "'VRPType' field only supports value 'UK.OBIE.VRPType.Sweeping'"),
-    REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID, "'Risk.PaymentContextCode' only supports values: ['PartyToParty', 'TransferToSelf']"),
-    REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID, "'PSUAuthenticationMethods' field only supports value 'UK.OBIE.SCANotRequired'"),
-    REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID, "'ValidToDateTime' must be > 'ValidFromDateTime'"),
-    REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID, "'ValidFromDateTime' cannot be more than %s days in the future"),
-    REQUEST_AMOUNT_MAX_2_DP(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_AMOUNT_MAX_2_DP, "Amount represented in field: '%s' can have a maximum of 2 decimal places"),
+    REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL,
+            "'MaximumIndividualAmount' must be >= %.2f"
+    ),
+    REQUEST_VRP_TYPE_MUST_BE_SWEEPING(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_VRP_TYPE_MUST_BE_SWEEPING,
+            "'VRPType' field only supports value 'UK.OBIE.VRPType.Sweeping'")
+    ,
+    REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID,
+            "'Risk.PaymentContextCode' only supports values: ['PartyToParty', 'TransferToSelf']"
+    ),
+    REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID,
+            "'PSUAuthenticationMethods' field only supports value 'UK.OBIE.SCANotRequired'"
+    ),
+    REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID,
+            "'ValidToDateTime' must be > 'ValidFromDateTime'"
+    ),
+    REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID,
+            "'ValidFromDateTime' cannot be more than %s days in the future"
+    ),
+    REQUEST_AMOUNT_MAX_2_DP(
+            HttpStatus.BAD_REQUEST,
+            ErrorCode.OBRI_REQUEST_AMOUNT_MAX_2_DP,
+            "Amount represented in field: '%s' can have a maximum of 2 decimal places"
+    ),
     REQUEST_UNDEFINED_ERROR_YET(
             HttpStatus.BAD_REQUEST,
             ErrorCode.OBRI_REQUEST_UNDEFINED_ERROR_YET,

--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/error/OBRIErrorType.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/model/error/OBRIErrorType.java
@@ -563,6 +563,13 @@ public enum OBRIErrorType {
             HttpStatus.BAD_REQUEST,
             ErrorCode.OBRI_REQUEST_VRP_LIMIT_BREACH_SIMULATION_NO_MATCHING_LIMIT_IN_CONSENT,
             "No Periodic Limit found in the consent for Header value '%s', unable to simulate the payment limitation breach"),
+    REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_MAX_INDIVIDUAL_AMOUNT_TOO_SMALL, "'MaximumIndividualAmount' must be >= %.2f"),
+    REQUEST_VRP_TYPE_MUST_BE_SWEEPING(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_TYPE_MUST_BE_SWEEPING, "'VRPType' field only supports value 'UK.OBIE.VRPType.Sweeping'"),
+    REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_RISK_PAYMENT_CONTEXT_CODE_INVALID, "'Risk.PaymentContextCode' only supports values: ['PartyToParty', 'TransferToSelf']"),
+    REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_PSU_AUTHENTICATION_METHODS_INVALID, "'PSUAuthenticationMethods' field only supports value 'UK.OBIE.SCANotRequired'"),
+    REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_CONSENT_VALID_TO_DATE_INVALID, "'ValidToDateTime' must be > 'ValidFromDateTime'"),
+    REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_VRP_CONSENT_VALID_FROM_DATE_INVALID, "'ValidFromDateTime' cannot be more than %s days in the future"),
+    REQUEST_AMOUNT_MAX_2_DP(HttpStatus.BAD_REQUEST, ErrorCode.OBRI_REQUEST_AMOUNT_MAX_2_DP, "Amount represented in field: '%s' can have a maximum of 2 decimal places"),
     REQUEST_UNDEFINED_ERROR_YET(
             HttpStatus.BAD_REQUEST,
             ErrorCode.OBRI_REQUEST_UNDEFINED_ERROR_YET,

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>2.0.0</version>
+        <version>2.1.0</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
- Adding error messages and codes for extended VRP validation rules
- Updating parent versions to 2.1.0 in order to supports OB version 3.1.10

Issue: https://github.com/ForgeCloud/ob-deploy/issues/883