### PR TITLE
888: Allow Danish and Latvian eIDAS cert TPP registration

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/constants/CountryCodes.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/constants/CountryCodes.java
@@ -86,7 +86,7 @@ public class CountryCodes {
         twoLetterToThreeLetterCodes.put("CU","CUB");
         twoLetterToThreeLetterCodes.put("CY","CYP");
         twoLetterToThreeLetterCodes.put("CZ","CZE");
-        twoLetterToThreeLetterCodes.put("DK","DNK");
+        twoLetterToThreeLetterCodes.put("DK","DEN");
         twoLetterToThreeLetterCodes.put("DJ","DJI");
         twoLetterToThreeLetterCodes.put("DM","DMA");
         twoLetterToThreeLetterCodes.put("DO","DOM");
@@ -148,7 +148,7 @@ public class CountryCodes {
         twoLetterToThreeLetterCodes.put("KW","KWT");
         twoLetterToThreeLetterCodes.put("KG","KGZ");
         twoLetterToThreeLetterCodes.put("LA","LAO");
-        twoLetterToThreeLetterCodes.put("LV","LVA");
+        twoLetterToThreeLetterCodes.put("LV","LAT");
         twoLetterToThreeLetterCodes.put("LB","LBN");
         twoLetterToThreeLetterCodes.put("LS","LSO");
         twoLetterToThreeLetterCodes.put("LR","LBR");


### PR DESCRIPTION
Danish and Latvian TPPs were failing to do dynamic client registration
due to a country code lookup that failed.

Issue: https://github.com/forgecloud/ob-deploy/issues/888