### PR TITLE
949: Fix Three letter code mapping for Latvia

### DIFF
--- a/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/constants/CountryCodes.java
+++ b/forgerock-openbanking-model/src/main/java/com/forgerock/openbanking/constants/CountryCodes.java
@@ -154,7 +154,7 @@ public class CountryCodes {
         twoLetterToThreeLetterCodes.put("LR","LBR");
         twoLetterToThreeLetterCodes.put("LY","LBY");
         twoLetterToThreeLetterCodes.put("LI","LIE");
-        twoLetterToThreeLetterCodes.put("LT","LTU");
+        twoLetterToThreeLetterCodes.put("LT","LTH");
         twoLetterToThreeLetterCodes.put("LU","LUX");
         twoLetterToThreeLetterCodes.put("MO","MAC");
         twoLetterToThreeLetterCodes.put("MK","MKD");


### PR DESCRIPTION
OBIE use LTH not LTU

Issue: https://github.com/forgecloud/ob-deploy/issues/949